### PR TITLE
Adds tests for vm custom elements

### DIFF
--- a/playwright-tests/testUtils.js
+++ b/playwright-tests/testUtils.js
@@ -1,9 +1,11 @@
 import { expect } from "@playwright/test";
 
-export const pauseIfVideoRecording = async (page, pause = 500) => {
+export const pauseIfVideoRecording = async (page) => {
   let isVideoRecorded = (await page.video()) ? true : false;
   if (isVideoRecorded) {
-    await page.waitForTimeout(pause);
+    await page.waitForTimeout(500);
+  } else {
+    await page.waitForTimeout(100);
   }
 };
 

--- a/playwright-tests/testUtils.js
+++ b/playwright-tests/testUtils.js
@@ -29,3 +29,12 @@ export const clickWhenSelectorIsVisible = async (page, selector) => {
   waitForSelectorToBeVisible(page, selector);
   await page.click(selector);
 };
+
+export const escapeHtml = (html) => {
+  return html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};

--- a/playwright-tests/tests/vm/customelements.spec.js
+++ b/playwright-tests/tests/vm/customelements.spec.js
@@ -25,9 +25,10 @@ test("should throw error if a custom element is referenced from code, but not de
 
   // Expect error message to be displayed
   const errorMsg = await page.getByText("Error: Unknown element: Test");
+
   expect(errorMsg).toBeTruthy();
 
-  pauseIfVideoRecording(page);
+  await pauseIfVideoRecording(page);
 });
 
 test("should render custom element when defined, with attributes and children", async ({
@@ -57,7 +58,8 @@ test("should render custom element when defined, with attributes and children", 
 
   // Verify children
   const renderedChildren = await page.getByText("go somewhere");
+
   expect(renderedChildren).toBeTruthy();
 
-  pauseIfVideoRecording(page);
+  await pauseIfVideoRecording(page);
 });

--- a/playwright-tests/tests/vm/customelements.spec.js
+++ b/playwright-tests/tests/vm/customelements.spec.js
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import {
+  escapeHtml,
+  pauseIfVideoRecording,
+  waitForSelectorToBeVisible,
+} from "../../testUtils";
+
+test("should throw error if a custom element is referenced from code, but not defined", async ({
+  page,
+}) => {
+  // Navigate to the default route
+  await page.goto("/");
+
+  const code = escapeHtml("return <Test />;");
+
+  // Set code attribute to reference a non-existent custom element
+  await page.evaluate((code) => {
+    document.body.innerHTML = `
+    <near-social-viewer code="${code}" />
+    `;
+  }, code);
+
+  // Verify the viewer is visible
+  await waitForSelectorToBeVisible(page, "near-social-viewer");
+
+  // Expect error message to be displayed
+  const errorMsg = await page.getByText("Error: Unknown element: Test");
+  expect(errorMsg).toBeTruthy();
+
+  pauseIfVideoRecording(page);
+});
+
+test("should render custom element when defined, with attributes and children", async ({
+  page,
+}) => {
+  // Navigate to the default route
+  await page.goto("/");
+
+  const code = escapeHtml('return (<Link to="/anywhere">go somewhere</Link>);');
+
+  // Set code attribute to reference an existing custom element
+  await page.evaluate((code) => {
+    document.body.innerHTML = `
+    <near-social-viewer code="${code}" />
+    `;
+  }, code);
+
+  // Verify the viewer is visible
+  await waitForSelectorToBeVisible(page, "near-social-viewer");
+
+  // Expect the custom element to be rendered
+  const renderedLink = await page.getByRole("link");
+  expect(renderedLink).toBeTruthy();
+
+  // Verify attribute
+  expect(renderedLink).toHaveAttribute("href", "/anywhere");
+
+  // Verify children
+  const renderedChildren = await page.getByText("go somewhere");
+  expect(renderedChildren).toBeTruthy();
+
+  pauseIfVideoRecording(page);
+});


### PR DESCRIPTION
_Resolves #23_

- [x] should throw error if a custom element is referenced from code, but not defined

https://github.com/NEARBuilders/near-bos-webcomponent/assets/16282460/54eba638-9fbf-4259-81a0-111bbc0c0f25

- [x] should render custom element when defined, with attributes and children

https://github.com/NEARBuilders/near-bos-webcomponent/assets/16282460/b90b59f9-80bb-485d-a23a-395f6c2d436f



