### PR TITLE
POC: defining custom elements in the wc, passing to app

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,12 @@
     "react-bootstrap-typeahead": "^6.1.2",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
+    "react-webcam": "^7.2.0",
     "styled-components": "^5.3.6"
   },
   "scripts": {
     "webpack": "webpack",
-    "dev": "yarn run webpack --env mode=development",
+    "dev": "yarn run webpack --env mode=development --watch",
     "prod": "yarn run webpack --env mode=production",
     "prod:analyze": "yarn run prod --env presets=analyze",
     "build": "yarn run prod",

--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,7 @@ function Viewer({ widgetSrc, code, initialProps }) {
 }
 
 function App(props) {
-  const { src, code, initialProps, rpc, network, selectorPromise } = props;
+  const { src, code, initialProps, rpc, network, selectorPromise, customElements } = props;
   const { initNear } = useInitNear();
 
   useAccount();
@@ -90,6 +90,7 @@ function App(props) {
           }
           return <Link {...props} />;
         },
+        ...customElements
       },
       features: {
         enableComponentSrcDataKey: true,

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -1,0 +1,112 @@
+import React from "react";
+import Webcam from "react-webcam";
+import styled from "styled-components";
+
+const StyledOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-areas:
+    "top-left top-center top-right"
+    "center-left center center-right"
+    "bottom-left bottom-center bottom-right";
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+`;
+
+const OverlayZone = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  grid-area: ${(props) => props.area};
+`;
+
+class Camera extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.webcamRef = React.createRef();
+    this.state = {
+      facingMode: this.props.videoConstraints.facingMode,
+      videoConstraints: this.props.videoConstraints,
+    };
+  }
+
+  componentDidMount() {
+    this.updateVideoConstraints();
+  }
+
+  updateVideoConstraints = () => {
+    if (this.containerRef.current) {
+      const { width, height } = this.containerRef.current.getBoundingClientRect();
+      this.setState((prevState) => ({
+        videoConstraints: {
+          ...prevState.videoConstraints,
+          width,
+          height,
+        },
+      }));
+    }
+  };
+
+  getScreenshot = () => {
+    if (this.webcamRef.current) {
+      return this.webcamRef.current.getScreenshot();
+    }
+    return null;
+  };
+
+  toggleFacingMode = () => {
+    this.setState((prevState) => ({
+      facingMode: prevState.facingMode === "user" ? "environment" : "user",
+    }));
+  };
+
+  render() {
+    const { audio, mirrored, screenshotFormat, overlayComponents } = this.props;
+    const { facingMode, videoConstraints } = this.state;
+
+    const webcamAPI = {
+      getScreenshot: this.getScreenshot,
+      toggleFacingMode: this.toggleFacingMode,
+      facingMode,
+    };
+
+    return (
+      <div ref={this.containerRef} style={{ position: "relative", width: "100%", height: "100%", overflow: "hidden" }}>
+        <Webcam
+          audio={audio}
+          mirrored={mirrored}
+          screenshotFormat={screenshotFormat}
+          videoConstraints={{ ...videoConstraints, facingMode }}
+          ref={this.webcamRef}
+          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        />
+        <StyledOverlay>
+          {Object.entries(overlayComponents).map(([zone, Component]) => (
+            <OverlayZone key={zone} area={zone}>
+              <Component {...webcamAPI} />
+            </OverlayZone>
+          ))}
+        </StyledOverlay>
+      </div>
+    );
+  }
+}
+
+Camera.defaultProps = {
+  audio: false,
+  mirrored: false,
+  screenshotFormat: "image/jpeg",
+  videoConstraints: {
+    facingMode: "user",
+    width: 1280,
+    height: 720,
+  },
+  overlayComponents: {},
+};
+
+export default Camera;

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -24,7 +24,7 @@ const OverlayZone = styled.div`
   grid-area: ${(props) => props.area};
 `;
 
-class Camera extends React.Component {
+class Camera extends React.Component { // This needs to be a class component
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
@@ -35,6 +35,8 @@ class Camera extends React.Component {
     };
   }
 
+  // (and cannot use hooks, like useState or useEffect)
+  // or access contexts
   componentDidMount() {
     this.updateVideoConstraints();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import Camera from "./Camera";
 
 class NearSocialViewerElement extends HTMLElement {
   constructor() {
@@ -45,6 +46,9 @@ class NearSocialViewerElement extends HTMLElement {
         rpc={rpc}
         network={network}
         selectorPromise={this.selectorPromise}
+        customElements={{
+          Camera: (props) => <Camera {...props} />,
+        }}
       />
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./App";
+import App from "./App"; // what if this was bundled?
 import Camera from "./Camera";
 
+// should NearSocialViewerElement be a newly defined and extendable class? to maintain consistency?
+// so this would could be "class NearWebcamViewerElement extends NearSocialViewerElement"
 class NearSocialViewerElement extends HTMLElement {
   constructor() {
     super();
@@ -46,7 +48,7 @@ class NearSocialViewerElement extends HTMLElement {
         rpc={rpc}
         network={network}
         selectorPromise={this.selectorPromise}
-        customElements={{
+        customElements={{ // defining and importing custom elements here
           Camera: (props) => <Camera {...props} />,
         }}
       />
@@ -60,4 +62,5 @@ class NearSocialViewerElement extends HTMLElement {
   }
 }
 
-customElements.define("near-social-viewer", NearSocialViewerElement);
+// other custom versions of near-bos-webcomponent should define their own element tag
+customElements.define("near-webcam-viewer", NearSocialViewerElement);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12484,6 +12484,11 @@ react-uuid@^1.0.2:
   resolved "https://registry.yarnpkg.com/react-uuid/-/react-uuid-1.0.3.tgz#77418d1ebd29b4c4ab8e457272887d489aa87836"
   integrity sha512-cw6Rr6JphvsdK4xHPGBjKD7XSH6Y6i4NJFWUO3OiDd7NLcR8xVeQ3CfeKm7h+S5tpZZVfbH3Tkrz/ydsIiV8pA==
 
+react-webcam@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/react-webcam/-/react-webcam-7.2.0.tgz#64141c4c7bdd3e956620500187fa3fcc77e1fd49"
+  integrity sha512-xkrzYPqa1ag2DP+2Q/kLKBmCIfEx49bVdgCCCcZf88oF+0NPEbkwYk3/s/C7Zy0mhM8k+hpdNkBLzxg8H0aWcg==
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
-- DO NOT MERGE --

![image](https://github.com/NEARBuilders/near-bos-webcomponent/assets/16282460/acb853a0-a78a-4bf8-b36d-a2608075be2b)

This is a small proof of concept exploring a how to simplify development of new near-bos-webcomponents that offer unique custom elements and nothing else. 

### Here is a quick rundown:
1. Several projects use near-bos-wc as a starter template to offer and deploy their own custom elements (tldraw Canvas, livepeer Player & Broadcast, etc) -- these apps do not change anything else about the web component, only the custom elements that are offered.
2. Keeping up to date with the core, stable near-bos-wc can be difficult needing to rebase unrelated, but necessary changes 
3. The app that holds the VM is becoming increasingly black-boxed, and in this POC, creating a new web component that offers unique custom elements would only need to extend and publish a version of the html element itself, rather than the underlying app. 

### Highlights of this solution

1. This passes "customElements" as props from the element definition to the "App" that uses them.
2. The "App" with near-social-vm installed can be separately bundled and pulled in from CDN, meaning easier updates and releases to the core functionality, while also enabling freedom to swap it out and completely change how it works (what if a version of the VM was made to expect HTMLElement customElements instead of React.Components? Would maintain the same interface and should pass the same regression tests)
3. Because of these unique custom elements, these web components should probably be named something other than "near-social-viewer" and should maintain their own releases. Maybe further simplification is to extend the NearSocialViewerElement class, to enforce uniformity. 

### Possible next steps
- [ ] Separately bundle and distribute the App with near-social-vm
- [ ] export NearSocialViewerElement class for easy extension
- [ ] How can we leverage ES modules more?

Please let me know what you think and if this direction should be pursued!