### PR TITLE
Fixes hot reload socket tests

### DIFF
--- a/src/utils/bos-workspace.js
+++ b/src/utils/bos-workspace.js
@@ -38,7 +38,7 @@ export function useRedirectMap() {
 
         socket.on("fileChange", (d) => {
           console.log("File change detected via WebSocket", d);
-          setDevJson(d);
+          setDevJson(d.components);
         });
 
         socket.on("connect_error", (error) => {


### PR DESCRIPTION
Although hot reload tests were passing, they mocked data incorrectly and so did not reflect the actual implementation. This is fixed now.

Data received from socket server is:

```json
{
    "components": {
        "quickstart.near/widget/deeply.nested.home": {
            "code": "return <p>Hello world</p>;\n"
        },
    },
    "data": {}
}
```